### PR TITLE
workaround for watchdog issues within pytests and more bug fixes

### DIFF
--- a/examples/GridAPPS-DAgent/setup.py
+++ b/examples/GridAPPS-DAgent/setup.py
@@ -8,7 +8,8 @@ agent_package = 'gridappsdvolttron'
 
 # Find the version number from the main module
 agent_module = agent_package + '.' + MAIN_MODULE
-_temp = __import__(agent_module, globals(), locals(), ['__version__'], -1)
+# -1 not valid import level in python3
+_temp = __import__(agent_module, globals(), locals(), ['__version__'], 0)
 __version__ = _temp.__version__
 
 # Setup

--- a/examples/MatLabAgent_v2/setup.py
+++ b/examples/MatLabAgent_v2/setup.py
@@ -8,7 +8,8 @@ agent_package = 'matlab_agentV2'
 
 # Find the version number from the main module
 agent_module = agent_package + '.' + MAIN_MODULE
-_temp = __import__(agent_module, globals(), locals(), ['__version__'], -1)
+# -1 not valid import level in python3
+_temp = __import__(agent_module, globals(), locals(), ['__version__'], 0)
 __version__ = _temp.__version__
 
 # Setup

--- a/services/core/Darksky/darksky/agent.py
+++ b/services/core/Darksky/darksky/agent.py
@@ -224,7 +224,9 @@ class Darksky(BaseWeatherAgent):
         :return: dictionary containing a mapping of service point
         names to standard point names with optional
         """
-        return pkg_resources.resource_stream(__name__, "data/name_mapping.csv")
+        # returning resource file instead of stream, as csv.DictReader require file path or file like object opened in
+        # text mode.
+        return pkg_resources.resource_filename(__name__, "data/name_mapping.csv")
 
     def get_darksky_data(self, service, location, timestamp=None):
         """

--- a/services/core/Darksky/setup.py
+++ b/services/core/Darksky/setup.py
@@ -57,7 +57,8 @@ if not agent_package:
 
 # Find the version number from the main module
 agent_module = agent_package + '.' + MAIN_MODULE
-_temp = __import__(agent_module, globals(), locals(), ['__version__'], -1)
+# -1 not valid import level in python3
+_temp = __import__(agent_module, globals(), locals(), ['__version__'], 0)
 __version__ = _temp.__version__
 
 # Setup

--- a/services/core/InfluxdbHistorian/setup.py
+++ b/services/core/InfluxdbHistorian/setup.py
@@ -75,7 +75,7 @@ if not agent_package:
 
 # Find the version number from the main module
 agent_module = agent_package + '.' + MAIN_MODULE
-_temp = __import__(agent_module, globals(), locals(), ['__version__'], -0)
+_temp = __import__(agent_module, globals(), locals(), ['__version__'], 0)
 __version__ = _temp.__version__
 
 # Setup

--- a/services/core/WeatherDotGov/setup.py
+++ b/services/core/WeatherDotGov/setup.py
@@ -57,7 +57,8 @@ if not agent_package:
 
 # Find the version number from the main module
 agent_module = agent_package + '.' + MAIN_MODULE
-_temp = __import__(agent_module, globals(), locals(), ['__version__'], -1)
+# -1 not valid import level in python3
+_temp = __import__(agent_module, globals(), locals(), ['__version__'], 0)
 __version__ = _temp.__version__
 
 # Setup

--- a/services/core/WeatherDotGov/weatherdotgov/agent.py
+++ b/services/core/WeatherDotGov/weatherdotgov/agent.py
@@ -61,13 +61,17 @@ import logging
 import re
 import sys
 import json
-import requests
 import grequests
 import datetime
 import pkg_resources
 from volttron.platform.agent.base_weather import BaseWeatherAgent
 from volttron.platform.agent import utils
 from volttron.utils.docs import doc_inherit
+
+# requests should be imported after grequests
+# as grequests monkey patches ssl and requests imports ssl
+# TODO do we need the requests at all.. TODO test with RMQ
+import requests
 
 __version__ = "2.0.0"
 
@@ -133,7 +137,9 @@ class WeatherDotGovAgent(BaseWeatherAgent):
         :return: dictionary containing a mapping of service point
         names to standard point names with optional
         """
-        return pkg_resources.resource_stream(__name__, "data/name_mapping.csv")
+        # returning resource file instead of stream, as csv.DictReader require file path or file like object opened in
+        # text mode.
+        return pkg_resources.get_resource_filename(__name__, "data/name_mapping.csv")
 
     def get_location_string(self, location):
         """

--- a/volttron/platform/agent/base_weather.py
+++ b/volttron/platform/agent/base_weather.py
@@ -185,7 +185,7 @@ class BaseWeatherAgent(Agent):
                                       actions=["NEW", "UPDATE"],
                                       pattern="config")
         except Exception as e:
-            _log.error("Failed to load weather agent settings.")
+            _log.error("Failed to load weather agent settings.Exception: {}".format(e))
             self.vip.health.set_status(STATUS_BAD,
                                        "Failed to load weather agent settings."
                                        "Error: {}".format(e))

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -109,7 +109,7 @@ else:
 _log = logging.getLogger(os.path.basename(sys.argv[0])
                          if __name__ == '__main__' else __name__)
 
-logging.getLogger("watchdog.observers.inotify_buffer").setLevel(logging.DEBUG)
+logging.getLogger("watchdog.observers.inotify_buffer").setLevel(logging.INFO)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
 VOLTTRON_INSTANCES = '~/.volttron_instances'
 

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -49,7 +49,7 @@ from ...platform import get_home
 from ...platform import jsonapi
 from ...platform.agent.web import Response
 from ...platform.certs import Certs
-from ...utils import FileReloader
+from ...utils import VolttronHomeFileReloader
 from ...utils.persistance import PersistentDict
 
 _log = logging.getLogger(__name__)

--- a/volttron/platform/web/authenticate_endpoint.py
+++ b/volttron/platform/web/authenticate_endpoint.py
@@ -10,7 +10,7 @@ from passlib.hash import argon2
 
 from volttron.platform import get_home
 from volttron.platform.agent.web import Response
-from volttron.utils import FileReloader
+from volttron.utils import VolttronHomeFileReloader
 from volttron.utils.persistance import PersistentDict
 
 _log = logging.getLogger(__name__)

--- a/volttron/utils/__init__.py
+++ b/volttron/utils/__init__.py
@@ -2,6 +2,11 @@ import re
 
 from watchdog.events import PatternMatchingEventHandler
 
+from volttron.platform import get_home
+import logging
+
+_log = logging.getLogger(__name__)
+
 
 def is_ip_private(vip_address):
     """ Determines if the passed vip_address is a private ip address or not.
@@ -31,9 +36,32 @@ def get_hostname():
     return hostname
 
 
-class FileReloader(PatternMatchingEventHandler):
+class VolttronHomeFileReloader(PatternMatchingEventHandler):
+    """
+    Extends PatternMatchingEvent handler to watch changes to a singlefile/file pattern within volttron home.
+    filetowatch should be path relative to volttron home.
+    For example filetowatch auth.json with watch file <volttron_home>/auth.json.
+    filetowatch *.json will watch all json files in <volttron_home>
+    """
     def __init__(self, filetowatch, callback):
-        super(FileReloader, self).__init__(['*/'+filetowatch])
+        super(VolttronHomeFileReloader, self).__init__([get_home() + '/' + filetowatch])
+        _log.debug("patterns is {}".format([get_home() + '/' + filetowatch]))
+        self._callback = callback
+
+    def on_any_event(self, event):
+        _log.debug("Calling callback on event {}".format(event))
+        self._callback()
+
+
+class AbsolutePathFileReloader(PatternMatchingEventHandler):
+    """
+    Extends PatternMatchingEvent handler to watch changes to a singlefile/file pattern within volttron home.
+    filetowatch should be path relative to volttron home.
+    For example filetowatch auth.json with watch file <volttron_home>/auth.json.
+    filetowatch *.json will watch all json files in <volttron_home>
+    """
+    def __init__(self, filetowatch, callback):
+        super(VolttronHomeFileReloader, self).__init__([filetowatch])
         self._callback = callback
         self._filetowatch = filetowatch
 


### PR DESCRIPTION
workaround for watchdog issues within pytests
Fixed:
1. `__import__ ` statements in setup.py
2. gerequest, requests import order for monkey patching
3. Using pkg_resources.get_resource_filename instead of get_resource_stream to handle byte/text file error in csv.DictReader