### PR TITLE
reverting to cryptography 2.2.2

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -121,7 +121,7 @@ extras_require = {
         'websocket-client',
     ],
     'rabbitmq': [
-        'cryptography',
+        'cryptography==2.2.2',
         'gevent-pika'
     ],
     'weather': [

--- a/volttron/platform/certs.py
+++ b/volttron/platform/certs.py
@@ -813,7 +813,11 @@ class Certs(object):
         ca_cert = self.cert(ca_name)
 
         issuer = ca_cert.subject
-        ski = x509.SubjectKeyIdentifier.from_public_key(ca_cert.public_key())
+        # cryptography 2.7
+        # ski = x509.SubjectKeyIdentifier.from_public_key(ca_cert.public_key())
+        # crptography 2.2.2
+        ski = ca_cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier)
 
         key = rsa.generate_private_key(
             public_exponent=65537,
@@ -868,9 +872,15 @@ class Certs(object):
                 x509.BasicConstraints(ca=True, path_length=0),
                 critical=True
             ).add_extension(
-                x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+                x509.SubjectKeyIdentifier(
+                    _create_fingerprint(key.public_key())),
                 critical=False
             )
+            # cryptography 2.7
+            # .add_extension(
+            #     x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            #     critical=False
+            # )
         else:
             # if type is server or client.
             cert_builder = cert_builder.add_extension(


### PR DESCRIPTION
Not much luck with cryptography 2.2.2. But cryptography 2.7 surely breaks volttron connection with rmq. So better to revert anyway for now and create a separate issue to upgrade cryptography